### PR TITLE
Remove unnecessary xmllite dependency

### DIFF
--- a/src/impl/base.h
+++ b/src/impl/base.h
@@ -3,7 +3,6 @@
 #if defined(_WIN32)
 #include <windows.h>
 #include <shlwapi.h>
-#include <xmllite.h>
 #else
 #include <sys/stat.h>
 #include <fcntl.h>


### PR DESCRIPTION
Including xmllite causes issues when trying to interoperate between Ro* APIs that use IUnknown and cppwinrt's winrt::Windows::Foundation::IUnknown