### PR TITLE
Add the ability to load a new database file into an existing cache

### DIFF
--- a/src/impl/winmd_reader/cache.h
+++ b/src/impl/winmd_reader/cache.h
@@ -138,6 +138,8 @@ namespace winmd::reader
             remove(members.delegates, name);
         }
 
+        // This won't invalidate any existing database or row_base (e.g. TypeDef) instances
+        // However, it may invalidate iterators and references to namespace_members, because those are stored in std::vector
         void add_database(std::string_view const& file)
         {
             auto& db = m_databases.emplace_back(file, this);

--- a/test/cache.cpp
+++ b/test/cache.cpp
@@ -1,0 +1,89 @@
+#include "pch.h"
+#include <winmd_reader.h>
+
+using namespace winmd::reader;
+
+TEST_CASE("cache_add_invalidate")
+{
+    std::array<char, 260> local{};
+
+#ifdef _WIN64
+    ExpandEnvironmentStringsA("%windir%\\System32\\WinMetadata", local.data(), static_cast<uint32_t>(local.size()));
+#else
+    ExpandEnvironmentStringsA("%windir%\\SysNative\\WinMetadata", local.data(), static_cast<uint32_t>(local.size()));
+#endif
+
+    std::filesystem::path winmd_dir = local.data();
+    auto file_path = winmd_dir;
+    file_path.append("Windows.Foundation.winmd");
+
+    cache c(file_path.string());
+
+    // Get a type and a database and verify that neither are invalidated by adding a new db
+    TypeDef IStringable = c.find("Windows.Foundation", "IStringable");
+    auto const db = &(c.databases().front());
+
+    file_path = winmd_dir;
+    file_path.append("Windows.Data.winmd");
+    c.add_database(file_path.string());
+
+    TypeDef IStringable2 = c.find("Windows.Foundation", "IStringable");
+    REQUIRE(IStringable == IStringable2);
+
+    auto const db2 = &(c.databases().front());
+    REQUIRE(db == db2);
+}
+
+TEST_CASE("cache_add")
+{
+    std::array<char, 260> local{};
+
+#ifdef _WIN64
+    ExpandEnvironmentStringsA("%windir%\\System32\\WinMetadata", local.data(), static_cast<uint32_t>(local.size()));
+#else
+    ExpandEnvironmentStringsA("%windir%\\SysNative\\WinMetadata", local.data(), static_cast<uint32_t>(local.size()));
+#endif
+
+    std::filesystem::path winmd_dir = local.data();
+    auto file_path = winmd_dir;
+    file_path.append("Windows.Foundation.winmd");
+
+    cache c(file_path.string());
+
+    TypeDef JsonValue = c.find("Windows.Data.Json", "JsonValue");
+    REQUIRE(!JsonValue);
+
+    file_path = winmd_dir;
+    file_path.append("Windows.Data.winmd");
+    c.add_database(file_path.string());
+
+    JsonValue = c.find("Windows.Data.Json", "JsonValue");
+    REQUIRE(!!JsonValue);
+    REQUIRE(JsonValue.TypeName() == "JsonValue");
+    REQUIRE(JsonValue.TypeNamespace() == "Windows.Data.Json");
+}
+
+TEST_CASE("cache_add_duplicate")
+{
+    std::array<char, 260> local{};
+
+#ifdef _WIN64
+    ExpandEnvironmentStringsA("%windir%\\System32\\WinMetadata", local.data(), static_cast<uint32_t>(local.size()));
+#else
+    ExpandEnvironmentStringsA("%windir%\\SysNative\\WinMetadata", local.data(), static_cast<uint32_t>(local.size()));
+#endif
+
+    std::filesystem::path winmd_dir = local.data();
+    auto file_path = winmd_dir;
+    file_path.append("Windows.Foundation.winmd");
+
+    cache c(file_path.string());
+
+    TypeDef IStringable = c.find("Windows.Foundation", "IStringable");
+
+    // Add a winmd with duplicate types, and verify the original types aren't invalidated.
+    c.add_database(file_path.string());
+
+    TypeDef IStringable2 = c.find("Windows.Foundation", "IStringable");
+    REQUIRE(IStringable == IStringable2);
+}

--- a/test/winmd.vcxproj
+++ b/test/winmd.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="cache.cpp" />
     <ClCompile Include="database.cpp" />
     <ClCompile Include="main.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>


### PR DESCRIPTION
This adds the ability to dynamically add a new db to an existing cache.

Because it uses `std::list` and `std::map`, this won't invalidate any existing instances of `database` or `row_base` (e.g. `TypeDef`).

However, iterators and references to elements of `namespace_members` could be invalidated due to them using `std::vector`. But this is a non-scenario (don't go adding new winmds while iterating over namespace members).