### PR TITLE
Fix issue when two filter "excludes" have the same string length

### DIFF
--- a/src/impl/winmd_reader/filter.h
+++ b/src/impl/winmd_reader/filter.h
@@ -20,8 +20,7 @@ namespace winmd::reader
 
             std::sort(m_rules.begin(), m_rules.end(), [](auto const& lhs, auto const& rhs)
             {
-                auto size_compare = int(lhs.first.size()) - int(rhs.first.size());
-                return (size_compare > 0) || ((size_compare == 0) && !lhs.second);
+                return std::pair{ lhs.first.size(), lhs.second } > std::pair{ rhs.first.size(), rhs.second };
             });
         }
 

--- a/test/filter.cpp
+++ b/test/filter.cpp
@@ -1,0 +1,40 @@
+#include "pch.h"
+#include <winmd_reader.h>
+
+using namespace winmd::reader;
+
+TEST_CASE("filter_simple")
+{
+    std::vector<std::string> include = { "N1", "N3", "N3.N4.N5" };
+    std::vector<std::string> exclude = { "N2", "N3.N4" };
+
+    filter f{ include, exclude };
+
+    REQUIRE(!f.empty());
+
+    REQUIRE(!f.includes("NN.T"));
+
+    REQUIRE(f.includes("N1.T"));
+    REQUIRE(f.includes("N3.T"));
+
+    REQUIRE(!f.includes("N2.T"));
+    REQUIRE(!f.includes("N3.N4.T"));
+
+    REQUIRE(f.includes("N3.N4.N5.T"));
+}
+
+TEST_CASE("filter_excludes_same_length")
+{
+    std::vector<std::string> include = { "N.N1", "N.N2" };
+    std::vector<std::string> exclude = { "N.N3", "N.N4" };
+
+    filter f{ include, exclude };
+
+    REQUIRE(!f.empty());
+
+    REQUIRE(f.includes("N.N1.T"));
+    REQUIRE(f.includes("N.N2.T"));
+
+    REQUIRE(!f.includes("N.N3.T"));
+    REQUIRE(!f.includes("N.N4.T"));
+}

--- a/test/winmd.vcxproj
+++ b/test/winmd.vcxproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ClCompile Include="cache.cpp" />
     <ClCompile Include="database.cpp" />
+    <ClCompile Include="filter.cpp" />
     <ClCompile Include="main.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>


### PR DESCRIPTION
Found an issue where supplying multiple excludes with the same length caused bad behavior in Release and asserts in Debug.

Added test cases, and the second test case, "filter_excludes_same_length" was hitting an assert in debug due to a malformed sorting predicate in the `filter` class. In the test case, both `compare({"N.N3", false}, {"N.N4", false})` and `compare({"N.N4", false}, {"N.N3", false})` would return `true`, violating sorting constraints.

For the curious, `std::sort` (and the other C++ sortings I can think of) require a [Strict Weak Ordering](https://en.wikipedia.org/wiki/Weak_ordering#Strict_weak_orderings). What this means in C++ terms is, given a comparison object `compare`, the following requirements must be met:
- `compare(a, a) == false` for all `a`
- If `compare(a, b) == true` then `compare(b, a) == false`
- If `compare(a, b) == true` and `compare(b, c) == true` then `compare(a, c) == true`
- If `compare(a, b) == false` and `compare(b, a) == false` and `compare(b, c) == false` and `compare(c, b) == false` then `compare(a, c) == false` and `compare(c, a) == false` (aka transitivity of equivalence)

Fixes #21