### PR TITLE
Fix regression: filter should give exclude precedence.

### DIFF
--- a/src/impl/winmd_reader/filter.h
+++ b/src/impl/winmd_reader/filter.h
@@ -20,7 +20,7 @@ namespace winmd::reader
 
             std::sort(m_rules.begin(), m_rules.end(), [](auto const& lhs, auto const& rhs)
             {
-                return std::pair{ lhs.first.size(), lhs.second } > std::pair{ rhs.first.size(), rhs.second };
+                return std::pair{ lhs.first.size(), !lhs.second } > std::pair{ rhs.first.size(), !rhs.second };
             });
         }
 

--- a/test/filter.cpp
+++ b/test/filter.cpp
@@ -38,3 +38,15 @@ TEST_CASE("filter_excludes_same_length")
     REQUIRE(!f.includes("N.N3.T"));
     REQUIRE(!f.includes("N.N4.T"));
 }
+
+TEST_CASE("filter_exclude_include_precedence")
+{
+    std::vector<std::string> include = { "N.T" };
+    std::vector<std::string> exclude = { "N.T" };
+
+    filter f{ include, exclude };
+
+    REQUIRE(!f.empty());
+
+    REQUIRE(!f.includes("N.T"));
+}


### PR DESCRIPTION
#22 inadvertently caused a regression. The original behavior if two identical strings were both included and excluded was to give precedence to the exclusion. This change reverts back to the original behavior.