### PR TITLE
Expose `ImplMap`, `MemberForwarded` and `ModuleRef` fields

### DIFF
--- a/src/impl/winmd_reader/column.h
+++ b/src/impl/winmd_reader/column.h
@@ -241,6 +241,11 @@ namespace winmd::reader
         return get_target_row<TypeDef>(0);
     }
 
+    inline auto ImplMap::Module() const
+    {
+        return get_target_row<ModuleRef>(3);
+    }
+
     inline auto Constant::ValueBoolean() const
     {
         XLANG_ASSERT(Type() == ConstantType::Boolean);

--- a/src/impl/winmd_reader/index.h
+++ b/src/impl/winmd_reader/index.h
@@ -34,6 +34,14 @@ namespace winmd::reader
         auto MemberRef() const;
     };
 
+    template <> struct typed_index<MemberForwarded> : index_base<MemberForwarded>
+    {
+        using index_base<MemberForwarded>::index_base;
+        
+        auto Field() const;
+        auto MethodDef() const;
+    };
+
     template <> struct typed_index<ResolutionScope> : index_base<ResolutionScope>
     {
         using index_base<ResolutionScope>::index_base;

--- a/src/impl/winmd_reader/key.h
+++ b/src/impl/winmd_reader/key.h
@@ -54,6 +54,14 @@ namespace winmd::reader
         return get_row<reader::MemberRef>();
     }
 
+    inline auto typed_index<MemberForwarded>::Field() const {
+        return get_row<reader::Field>();
+    }
+
+    inline auto typed_index<MemberForwarded>::MethodDef() const {
+        return get_row<reader::MethodDef>();
+    }
+
     inline auto typed_index<ResolutionScope>::Module() const
     {
         return get_row<reader::Module>();

--- a/src/impl/winmd_reader/schema.h
+++ b/src/impl/winmd_reader/schema.h
@@ -428,6 +428,13 @@ namespace winmd::reader
     struct ImplMap : row_base<ImplMap>
     {
         using row_base::row_base;
+
+        auto Name() const
+        {
+            return get_string(2);
+        }
+
+        auto Module() const;
     };
 
     struct FieldRVA : row_base<FieldRVA>

--- a/src/impl/winmd_reader/schema.h
+++ b/src/impl/winmd_reader/schema.h
@@ -435,6 +435,11 @@ namespace winmd::reader
         }
 
         auto Module() const;
+
+        auto Member() const
+        {
+            return get_coded_index<MemberForwarded>(1);
+        }
     };
 
     struct FieldRVA : row_base<FieldRVA>

--- a/src/impl/winmd_reader/schema.h
+++ b/src/impl/winmd_reader/schema.h
@@ -418,6 +418,11 @@ namespace winmd::reader
         using row_base::row_base;
 
         auto CustomAttribute() const;
+
+        auto Name() const
+        {
+            return get_string(0);
+        }
     };
 
     struct ImplMap : row_base<ImplMap>


### PR DESCRIPTION
These weren't exposed to the schema, but they're necessary for querying something as basic as which module a function belongs to.