### PR TITLE
Allow synthesizing a TypeSig/GenericTypeSig directly from params.

### DIFF
--- a/src/impl/winmd_reader/signature.h
+++ b/src/impl/winmd_reader/signature.h
@@ -96,6 +96,14 @@ namespace winmd::reader
     {
         GenericTypeInstSig(table_base const* table, byte_view& data);
 
+        GenericTypeInstSig(coded_index<TypeDefOrRef> type, std::vector<TypeSig>&& args)
+            : m_type(type)
+            , m_generic_arg_count(static_cast<uint32_t>(args.size()))
+            , m_generic_args(std::move(args))
+        {
+            // If constructing directly, probably don't care about m_class_or_value
+        }
+
         ElementType ClassOrValueType() const noexcept
         {
             return m_class_or_value;
@@ -117,7 +125,7 @@ namespace winmd::reader
         }
 
     private:
-        ElementType m_class_or_value;
+        ElementType m_class_or_value{};
         coded_index<TypeDefOrRef> m_type;
         uint32_t m_generic_arg_count;
         std::vector<TypeSig> m_generic_args;
@@ -213,6 +221,12 @@ namespace winmd::reader
             }
         }
 
+        explicit TypeSig(value_type&& arg)
+            : m_type(std::move(arg))
+        {
+            // If constructing directly, probably don't actually care about m_element_type. Simply populate m_type
+        }
+
         value_type const& Type() const noexcept
         {
             return m_type;
@@ -256,11 +270,11 @@ namespace winmd::reader
         }
 
         static value_type ParseType(table_base const* table, byte_view& data);
-        bool m_is_szarray;
-        bool m_is_array;
-        int m_ptr_count;
+        bool m_is_szarray{};
+        bool m_is_array{};
+        int m_ptr_count{};
         std::vector<CustomModSig> m_cmod;
-        ElementType m_element_type;
+        ElementType m_element_type{};
         value_type m_type;
         uint32_t m_array_rank{};
         std::vector<uint32_t> m_array_sizes;


### PR DESCRIPTION
### Background
The `TypeSpec` table typically contains only the entries that need to appear in other tables, like the `InterfaceImpl` table (e.g. `IVector<T>` implementing `IIterable<T>`), and many of them use the generic type index, not a specific type. Most other generic types we encounter in winmds exist solely as a Signature in the blob heap.

### Reason for change
There are scenarios where we want to synthesize a `GenericTypeSig` directly from parameter types.

For example, cppwinrt has a debugger extension that could use `TypeSig` and `GenericTypeInstSig` to visualize generic types, but often the instantiated generic type can not be found in a table, and the type in the blob heap is only using generic type indices, rather than a concrete type.

Say we have an `IVector<int>`. We can find the definition of `IVector<T>`, and various method signatures for it and its base interfaces that use `T`. But there are no signatures that carry the instantiated type `int`.

This change allows us to create a new `GenericTypeInstSig` for a concrete instantiation using pre-existing types. This way, we can create a signatures for `IVector<int>.Size`, `IIterable<Object>.First()`, etc.

One note is that I'm makign some simlifying assumptions about constructing these, such as ignoring ref types, arrays, etc. If we get enough tooling that becomes even richer, we can revisit this and add more options for construction.